### PR TITLE
Change unique identifier to (uid, owner, group, queryparams), was before (uid, owner, group)

### DIFF
--- a/src/collective/bookmarks/api/utils.py
+++ b/src/collective/bookmarks/api/utils.py
@@ -41,7 +41,7 @@ def get_bookmark_from_request(request, loadjson=False):
 
 
 def bookmark_dict_to_json_dict(bookmark):
-    """Prepare result item for responseself.
+    """Prepare result item for response.
 
     Enrich more if needed.
     """


### PR DESCRIPTION
The change to unique identifier (uid, owner, group, queryparams) allows to bookmark query urls of a faceted navigation. 